### PR TITLE
Mark typescript dependency as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,12 @@
     "eslint": ">=7.2.0",
     "typescript": ">=3.8.0"
   },
+  {
+    "peerDependenciesMeta": {
+      "typescript": {
+        "optional": true
+      }
+    }
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
Both [yarn](https://classic.yarnpkg.com/en/docs/package-json#toc-peerdependenciesmeta) and [npm](https://github.com/npm/cli/pull/224) support `peerDependenciesMeta`.

Right now if you are using `eslint-plugin-prettierx` for a non-TS project you will have a warning:

```
warning " > eslint-plugin-prettierx@0.12.1" has unmet peer dependency "typescript@>=3.2.0".
```

`peerDependenciesMeta` will suppress this warning.