### PR TITLE
Updated peer dep for eslint to >=7 to match desc

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "~4.2.4"
   },
   "peerDependencies": {
-    "eslint": "^7.0.0"
+    "eslint": ">=7.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
This should allow eslint 8 to be used with this.  It seems to work fine when installing them both using `--force`.  The documentation on the README also says that eslint 7 or newer can be used so this brings this into alignment with the documentation as well.